### PR TITLE
Support emscripten >= 2.0.3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -114,7 +114,7 @@ test64: all64
 	-@rm -f foo.gz
 
 libz.bc: $(OBJS)
-	$(EMCC) $(OBJS) -o $@
+	$(EMCC) -r $(OBJS) -o $@
 	#-@ ($(RANLIB) $@ || true) >/dev/null 2>&1
 
 match.o: match.S


### PR DESCRIPTION
libz.bc is not created anymore and the build fails, probably due to "The default output format is now executable JavaScript" in Emscripten 2.0.3.
`-r` appears to be the fix for this situation.